### PR TITLE
Extended scraping

### DIFF
--- a/helpers/install-dependencies.js
+++ b/helpers/install-dependencies.js
@@ -1,5 +1,3 @@
-const { spawn } = require('child_process')
-
 module.exports = () => {
   if (!process.env.GITHUB_ACTIONS || process.env.GITHUB_REPOSITORY === 'kaskadi/action-collmex-scraper') {
     return
@@ -8,6 +6,8 @@ module.exports = () => {
   const callingRepo = process.cwd()
   const actionRepo = '/home/runner/work/_actions/kaskadi/action-collmex-scraper/master/'
   process.chdir(actionRepo)
+  console.log('INFO: installing action dependencies...')
   spawnSync('npm', ['i', '--only=prod'])
+  console.log('SUCCESS: dependencies installed!')
   process.chdir(callingRepo)
 }

--- a/helpers/scraper/get-docs-hrefs.js
+++ b/helpers/scraper/get-docs-hrefs.js
@@ -1,11 +1,11 @@
 module.exports = (page) => {
-  return page.evaluate(extractEndpointHrefs)
+  return page.evaluate(extractDocsHrefs)
   // return page.$$eval('#dv-hilfe p', ps => ps.map(p => p.textContent.trim()))
   //   .then(ps => ps.filter(p => p !== 'Szenarien'))
   //   .then(matchingIndex => page.$$eval(`#dv-hilfe p:nth-of-type(${matchingIndex + 1}) + ul a`, as => as.map(a => a.href)))
 }
 
-function extractEndpointHrefs () {
+function extractDocsHrefs () {
   const excludedSections = ['Inhalt', 'Szenarien']
   const sections = Array.from(document.querySelectorAll('#dv-hilfe p')).filter(section => !excludedSections.includes(section.textContent.trim()))
   return sections.flatMap(section => Array.from(section.nextSibling.querySelectorAll('a')).map(a => a.href))

--- a/helpers/scraper/get-docs-hrefs.js
+++ b/helpers/scraper/get-docs-hrefs.js
@@ -1,8 +1,5 @@
 module.exports = (page) => {
   return page.evaluate(extractDocsHrefs)
-  // return page.$$eval('#dv-hilfe p', ps => ps.map(p => p.textContent.trim()))
-  //   .then(ps => ps.filter(p => p !== 'Szenarien'))
-  //   .then(matchingIndex => page.$$eval(`#dv-hilfe p:nth-of-type(${matchingIndex + 1}) + ul a`, as => as.map(a => a.href)))
 }
 
 function extractDocsHrefs () {

--- a/helpers/scraper/get-endpoint-hrefs.js
+++ b/helpers/scraper/get-endpoint-hrefs.js
@@ -1,5 +1,12 @@
 module.exports = (page) => {
-  return page.$$eval('#dv-hilfe p', ps => ps.map(p => p.textContent.trim()))
-    .then(ps => ps.indexOf('Abfragen'))
-    .then(matchingIndex => page.$$eval(`#dv-hilfe p:nth-of-type(${matchingIndex + 1}) + ul a`, as => as.map(a => a.href)))
+  return page.evaluate(extractEndpointHrefs)
+  // return page.$$eval('#dv-hilfe p', ps => ps.map(p => p.textContent.trim()))
+  //   .then(ps => ps.filter(p => p !== 'Szenarien'))
+  //   .then(matchingIndex => page.$$eval(`#dv-hilfe p:nth-of-type(${matchingIndex + 1}) + ul a`, as => as.map(a => a.href)))
+}
+
+function extractEndpointHrefs () {
+  const excludedSections = ['Inhalt', 'Szenarien']
+  const sections = Array.from(document.querySelectorAll('#dv-hilfe p')).filter(section => !excludedSections.includes(section.textContent.trim()))
+  return sections.flatMap(section => Array.from(section.nextSibling.querySelectorAll('a')).map(a => a.href))
 }

--- a/helpers/scraper/scrape-hrefs-data.js
+++ b/helpers/scraper/scrape-hrefs-data.js
@@ -1,10 +1,10 @@
 let visitedPages = [] // track visited pages to protect ourselves from cross reference in docs
 
 module.exports = async (hrefs, browser) => {
-  return Promise.all(hrefs.map(scrapeEndpointData(browser)))
+  return Promise.all(hrefs.map(scrapeHrefData(browser)))
 }
 
-function scrapeEndpointData (browser) {
+function scrapeHrefData (browser) {
   return async href => {
     const page = await browser.newPage()
     await page.goto(href, { waitUntil: 'networkidle2' })
@@ -12,7 +12,7 @@ function scrapeEndpointData (browser) {
     visitedPages = [...visitedPages, href]
     const crawlingHrefs = await getCrawlingHrefs(page, getUrlPattern(href))
     await page.close()
-    const crawlingData = await Promise.all(crawlingHrefs.map(scrapeEndpointData(browser)))
+    const crawlingData = await Promise.all(crawlingHrefs.map(scrapeHrefData(browser)))
     data = [...data, ...crawlingData.flat(1)]
     return data
   }

--- a/helpers/scraper/scraper.js
+++ b/helpers/scraper/scraper.js
@@ -1,7 +1,7 @@
 const login = require('./login.js')
 const gotoDocs = require('./goto-docs.js')
-const getEndpointHrefs = require('./get-endpoint-hrefs.js')
-const scrapeEndpointsData = require('./scrape-endpoints-data.js')
+const getDocsHrefs = require('./get-docs-hrefs.js')
+const scrapeHrefsData = require('./scrape-hrefs-data.js')
 const userNr = process.env.USER_NR
 
 module.exports = async (page, browser) => {
@@ -10,10 +10,10 @@ module.exports = async (page, browser) => {
   console.log('INFO: navigating to API documentation page...')
   await gotoDocs(page, userNr)
   console.log('INFO: retrieving endpoints...')
-  const endpointsHrefs = await getEndpointHrefs(page)
+  const docsHrefs = await getDocsHrefs(page)
   await page.close()
   console.log('INFO: extracting endpoints data...')
-  const data = await scrapeEndpointsData(endpointsHrefs, browser)
+  const data = await scrapeHrefsData(docsHrefs, browser)
     .then(data => data.flat(1))
   return Object.fromEntries(data.map(data => [data.Satzart, data]))
 }


### PR DESCRIPTION
**Changes description**
Extended scraping range to cover the whole docs. The generated data was missing some important fields (like `MESSAGE`) which were located in another section of the one scraped and not referenced inside of the crawled links.

**Updated features**
- _scraper:_ extended range to cover the whole docs instead of limiting the scraping/crawling to the `query` section (and any referenced links)